### PR TITLE
Touchpad key SCI + Scancode fix

### DIFF
--- a/src/board/system76/common/kbscan.c
+++ b/src/board/system76/common/kbscan.c
@@ -251,6 +251,18 @@ bool kbscan_press(uint16_t key, bool pressed, uint8_t * layer) {
                         }
                     }
                     break;
+                case COMBO_TOUCHPAD:
+                    // Not actually a combo, just sends a keypress and an SCI
+                    if (kbscan_enabled)
+                        kbc_scancode(KF_E0 | 0x63, pressed);
+
+                    if (pressed && acpi_ecos != EC_OS_NONE) {
+                        if (!pmc_sci(&PMC_1, 0x0A)) {
+                            // In the case of ignored SCI, reset bit
+                            return false;
+                        }
+                    }
+                    break;
             }
             break;
         case (KT_SCI):

--- a/src/common/include/common/keymap.h
+++ b/src/common/include/common/keymap.h
@@ -56,6 +56,8 @@ uint16_t keymap_translate(uint16_t key);
 #define K_PRINT_SCREEN (KT_COMBO | COMBO_PRINT_SCREEN)
 #define COMBO_PAUSE 2
 #define K_PAUSE (KT_COMBO | COMBO_PAUSE)
+#define COMBO_TOUCHPAD 3
+#define K_TOUCHPAD (KT_COMBO | COMBO_TOUCHPAD)
 
 // SCI
 #define KT_SCI (0x4000)
@@ -104,8 +106,6 @@ uint16_t keymap_translate(uint16_t key);
 // More media keys
 #define K_MEDIA_NEXT (KF_E0 | 0x4D)
 #define K_MEDIA_PREV (KF_E0 | 0x15)
-// Custom scancode
-#define K_TOUCHPAD (KF_E0 | 0x63)
 
 // Function keys
 


### PR DESCRIPTION
Turn the touchpad key into a combo key. Unlike other combos, this combo sends a regular keypress, but also sends an SCI for handling the touchpad toggle in ACPI which is supported under Windows.