### PR TITLE
Allow sub-500 ms wakeups while in s0ix

### DIFF
--- a/src/board/system76/common/include/board/power.h
+++ b/src/board/system76/common/include/board/power.h
@@ -3,6 +3,8 @@
 #ifndef _BOARD_POWER_H
 #define _BOARD_POWER_H
 
+#include <stdbool.h>
+
 enum PowerState {
     POWER_STATE_OFF,
     POWER_STATE_S5,
@@ -11,6 +13,10 @@ enum PowerState {
 };
 
 extern enum PowerState power_state;
+
+#if EC_ESPI
+extern bool in_s0ix;
+#endif
 
 void power_init(void);
 void power_on(void);

--- a/src/board/system76/common/peci.c
+++ b/src/board/system76/common/peci.c
@@ -123,7 +123,7 @@ uint8_t peci_get_fan_duty(void) {
 
 #if EC_ESPI
     // Use PECI if platform is not in CS
-    peci_on = gpio_get(&SLP_S0_N);
+    peci_on = !in_s0ix;
 #else // EC_ESPI
     // Use PECI if in S0 state
     peci_on = power_state == POWER_STATE_S0;


### PR DESCRIPTION
This fixes the issue where the power LED blinks irregularly while Windows is suspended.

This also improves power consumption since it also delays PECI temperature polling, which allows the CPU to go back to sleep faster.

The value of 500ms was chosen arbitrarily but has been tested to work well with Windows 11 on NS50MU. Another way to do this would be to measure the actual S0ix residency to determine sleep state, but this is simpler and works well enough.

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>