### PR TITLE
Pmc hack

### DIFF
--- a/src/board/system76/common/acpi.c
+++ b/src/board/system76/common/acpi.c
@@ -19,6 +19,8 @@ extern uint8_t sci_extra;
 
 enum EcOs acpi_ecos = EC_OS_NONE;
 
+extern bool pmc_s0_hack;
+
 static uint8_t fcmd = 0;
 static uint8_t fdat = 0;
 static uint8_t fbuf[4] = { 0, 0, 0, 0 };
@@ -130,7 +132,11 @@ uint8_t acpi_read(uint8_t addr) {
 
         ACPI_16(0x42, battery_info.cycle_count);
 
-        ACPI_8(0x68, acpi_ecos);
+        case 0x68:
+            data = acpi_ecos;
+            // HACK: Kick PMC to fix suspend on lemp11
+            pmc_s0_hack = true;
+            break;
 
         case 0xBC:
             data = battery_get_start_threshold();

--- a/src/board/system76/darp8/board.mk
+++ b/src/board/system76/darp8/board.mk
@@ -4,6 +4,8 @@ EC=it5570e
 
 # Enable eSPI
 CFLAGS+=-DEC_ESPI=1
+# Apply PMC hack for S0ix
+CFLAGS+=-DPMC_S0IX_HACK=1
 
 # Include keyboard
 KEYBOARD=15in_102

--- a/src/board/system76/galp6/board.mk
+++ b/src/board/system76/galp6/board.mk
@@ -5,6 +5,9 @@ EC=it5570e
 # Enable eSPI
 CFLAGS+=-DEC_ESPI=1
 
+# Apply PMC hack for S0ix
+CFLAGS+=-DPMC_S0IX_HACK=1
+
 # Include keyboard
 KEYBOARD=14in_83
 

--- a/src/board/system76/gaze17-3050/board.mk
+++ b/src/board/system76/gaze17-3050/board.mk
@@ -5,6 +5,9 @@ EC=it5570e
 # Enable eSPI
 CFLAGS+=-DEC_ESPI=1
 
+# Apply PMC hack for S0ix
+CFLAGS+=-DPMC_S0IX_HACK=1
+
 # Include keyboard
 KEYBOARD=15in_102
 

--- a/src/board/system76/gaze17-3060/board.mk
+++ b/src/board/system76/gaze17-3060/board.mk
@@ -5,6 +5,9 @@ EC=it5570e
 # Enable eSPI
 CFLAGS+=-DEC_ESPI=1
 
+# Apply PMC hack for S0ix
+CFLAGS+=-DPMC_S0IX_HACK=1
+
 # Include keyboard
 KEYBOARD=15in_102
 

--- a/src/board/system76/lemp11/board.mk
+++ b/src/board/system76/lemp11/board.mk
@@ -5,6 +5,9 @@ EC=it5570e
 # Enable eSPI
 CFLAGS+=-DEC_ESPI=1
 
+# Apply PMC hack for S0ix
+CFLAGS+=-DPMC_S0IX_HACK=1
+
 # Include keyboard
 KEYBOARD=14in_83
 

--- a/src/board/system76/oryp9/board.mk
+++ b/src/board/system76/oryp9/board.mk
@@ -5,6 +5,9 @@ EC=it5570e
 # Enable eSPI
 CFLAGS+=-DEC_ESPI=1
 
+# Apply PMC hack for S0ix
+CFLAGS+=-DPMC_S0IX_HACK=1
+
 # Include keyboard
 KEYBOARD=15in_102
 


### PR DESCRIPTION
Based on commit 01885609e80cd66d809711ab49c23dbb68f9f6eb from system76/ec:

lemp11 sometimes fails to reach C10 and gets stuck in C0 during s2idle.
For some reason, sending a PMC SCI allows the CPU to go to C10.