### PR TITLE
board/system76/galp6/gpio.c: configure tachometer gpios correctly

### DIFF
--- a/src/board/system76/galp6/gpio.c
+++ b/src/board/system76/galp6/gpio.c
@@ -145,9 +145,9 @@ void gpio_init(void) {
     // PWR_BTN#
     GPCRD5 = GPIO_OUT;
     // CPU_FANSEN
-    GPCRD6 = GPIO_IN | GPIO_DOWN;
+    GPCRD6 = GPIO_ALT;
     // VGA_FANSEN
-    GPCRD7 = GPIO_IN | GPIO_DOWN;
+    GPCRD7 = GPIO_ALT;
     // SMC_BAT
     GPCRE0 = GPIO_ALT | GPIO_UP;
     // AC_PRESENT


### PR DESCRIPTION
Fixes tachometer on nv40pz. GPU tach untested since dGPU support is currently not enabled for this board.

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>