### PR TITLE
board/system76/darp8/board.mk: remove PMC S0IX hack

### DIFF
--- a/src/board/system76/darp8/board.mk
+++ b/src/board/system76/darp8/board.mk
@@ -4,8 +4,6 @@ EC=it5570e
 
 # Enable eSPI
 CFLAGS+=-DEC_ESPI=1
-# Apply PMC hack for S0ix
-CFLAGS+=-DPMC_S0IX_HACK=1
 
 # Include keyboard
 KEYBOARD=15in_102


### PR DESCRIPTION
Board is now using S3 so this is not needed anymore

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>