### PR TITLE
Reset PS/2 and KBC when on host power on and reset

### DIFF
--- a/src/board/system76/common/include/board/kbc.h
+++ b/src/board/system76/common/include/board/kbc.h
@@ -12,5 +12,6 @@ extern uint8_t kbc_leds;
 void kbc_init(void);
 bool kbc_scancode(uint16_t key, bool pressed);
 void kbc_event(struct Kbc * kbc);
+void kbc_clear_lock(void);
 
 #endif // _BOARD_KBC_H

--- a/src/board/system76/common/kbc.c
+++ b/src/board/system76/common/kbc.c
@@ -23,6 +23,11 @@ void kbc_init(void) {
     *(KBC.status) = BIT(4);
 }
 
+void kbc_clear_lock(void) {
+    // Set "key lock" to disabled
+    *(KBC.status) = BIT(4);
+}
+
 #define KBC_TIMEOUT 1000
 
 // Enable first port

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -8,6 +8,7 @@
 #include <board/config.h>
 #include <board/fan.h>
 #include <board/gpio.h>
+#include <board/kbc.h>
 #include <board/kbled.h>
 #include <board/lid.h>
 #include <board/peci.h>
@@ -257,6 +258,7 @@ void power_on(void) {
         DEBUG("failed to reach S0, powering off\n");
         power_off();
     } else {
+        kbc_clear_lock();
         ps2_reset(&PS2_1);
         ps2_reset(&PS2_TOUCHPAD);
     }
@@ -354,6 +356,7 @@ void power_cpu_reset(void) {
     fan_reset();
     // Reset KBC and touchpad states
     kbled_reset();
+    kbc_clear_lock();
     ps2_reset(&PS2_1);
     ps2_reset(&PS2_TOUCHPAD);
 }

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -14,6 +14,7 @@
 #include <board/power.h>
 #include <board/pmc.h>
 #include <board/pnp.h>
+#include <board/ps2.h>
 #include <common/debug.h>
 
 #include <ec/espi.h>
@@ -255,6 +256,9 @@ void power_on(void) {
     if (power_state != POWER_STATE_S0) {
         DEBUG("failed to reach S0, powering off\n");
         power_off();
+    } else {
+        ps2_reset(&PS2_1);
+        ps2_reset(&PS2_TOUCHPAD);
     }
 }
 
@@ -348,8 +352,10 @@ void power_cpu_reset(void) {
     acpi_reset();
     // Reset fans
     fan_reset();
-    //TODO: reset KBC and touchpad states
+    // Reset KBC and touchpad states
     kbled_reset();
+    ps2_reset(&PS2_1);
+    ps2_reset(&PS2_TOUCHPAD);
 }
 
 static bool power_button_disabled(void) {


### PR DESCRIPTION
Tested by doing the following a few times (5):

1. Reset through firmware setup
2. Poweroff from Boot Manager menu and power on using single power button press
3. Poweroff from GRUB menu and power on using single power button press
4. Reboot from Ubuntu
5. Ungraceful shutdown from Ubuntu (5s power button override) and power on

Before the change, the keyboard hang would appear at least once.  Now it doesn't appear when used in conjunction with https://github.com/Dasharo/edk2/pull/53, unless the issue with BIOS settings reset/black screen hang occurs (then the log does not even appear and no way to check if there is no prompt). 

Also noticed that the PS2 driver in EDK2 sometimes produce error codes indicating that KBC status register had the lock bit active (BIT4 zeroed), most often it was happening after ungraceful shutdown with power button override.