### PR TITLE
scripts/lint/02-clang-format.sh: print error message on fail

### DIFF
--- a/scripts/lint/02-clang-format.sh
+++ b/scripts/lint/02-clang-format.sh
@@ -28,6 +28,7 @@ FMT_OPTS=(
 _output=$(clang-format "${FMT_OPTS[@]}" "${FILES[@]}" 2>&1)
 if [[ $_output != "" ]]; then
     failed
+    echo "$_output"
     exit 1
 fi
 


### PR DESCRIPTION
Print a more helpful error message on lint failure.