### PR TITLE
S0ix fix

### DIFF
--- a/src/board/system76/common/peci.c
+++ b/src/board/system76/common/peci.c
@@ -78,13 +78,6 @@ int16_t peci_set_fan_curve(uint8_t count, struct FanPoint *points) {
     return 0;
 }
 
-#if CONFIG_PECI_OVER_ESPI
-
-// Maximum OOB channel response time in ms
-#define PECI_ESPI_TIMEOUT 10
-
-void peci_init(void) {}
-
 // Returns true if peci is available
 bool peci_available(void) {
     // Ensure power state is up to date
@@ -94,6 +87,7 @@ bool peci_available(void) {
     if (power_state != POWER_STATE_S0)
         return false;
 
+#if CONFIG_BUS_ESPI
     // Currently waiting for host reset, PECI is not available
     if (espi_host_reset)
         return false;
@@ -106,7 +100,18 @@ bool peci_available(void) {
     // If VW_HOST_C10 virtual wire is VWS_HIGH, PECI will wake the CPU
     //TODO: wake CPU every 8 seconds following Intel recommendation?
     return (vw_get(&VW_HOST_C10) != VWS_HIGH);
+#else
+    // PECI is available if PLTRST# is high
+    return gpio_get(&BUF_PLT_RST_N);
+#endif // CONFIG_BUS_ESPI
 }
+
+#if CONFIG_PECI_OVER_ESPI
+
+// Maximum OOB channel response time in ms
+#define PECI_ESPI_TIMEOUT 10
+
+void peci_init(void) {}
 
 // Returns true on success, false on error
 bool peci_get_temp(int16_t *data) {
@@ -285,19 +290,6 @@ void peci_init(void) {
     HOCTL2R = 0x01;
     // Set VTT to 1V
     PADCTLR = 0x02;
-}
-
-// Returns true if peci is available
-bool peci_available(void) {
-    // Ensure power state is up to date
-    update_power_state();
-
-    // Power state must be S0 for PECI to be useful
-    if (power_state != POWER_STATE_S0)
-        return false;
-
-    // PECI is available if PLTRST# is high
-    return gpio_get(&BUF_PLT_RST_N);
 }
 
 // Returns true on success, false on error

--- a/src/board/system76/common/peci.c
+++ b/src/board/system76/common/peci.c
@@ -158,6 +158,8 @@ bool peci_get_temp(int16_t *data) {
             return false;
         }
     }
+    // Clear upstream done status
+    ESUCTRL0 = ESUCTRL0_DONE;
 
     // Wait for response
     //TODO: do this asynchronously to avoid delays?
@@ -178,10 +180,14 @@ bool peci_get_temp(int16_t *data) {
         uint8_t low = PUTOOBDB[5];
         uint8_t high = PUTOOBDB[6];
         *data = (((int16_t)high << 8) | (int16_t)low);
+        // Clear PUT_OOB status
+        ESOCTRL0 = ESOCTRL0_STATUS;
         return true;
     } else {
         // Did not receive enough data
         DEBUG("peci_get_temp: len %d < 7\n", len);
+        // Clear PUT_OOB status
+        ESOCTRL0 = ESOCTRL0_STATUS;
         return false;
     }
 }
@@ -246,6 +252,8 @@ int16_t peci_wr_pkg_config(uint8_t index, uint16_t param, uint32_t data) {
             return false;
         }
     }
+    // Clear upstream done status
+    ESUCTRL0 = ESUCTRL0_DONE;
 
     // Wait for response
     //TODO: do this asynchronously to avoid delays?
@@ -265,6 +273,10 @@ int16_t peci_wr_pkg_config(uint8_t index, uint16_t param, uint32_t data) {
 
         // Received enough data for status code
         int16_t cc = (int16_t)PUTOOBDB[5];
+
+        // Clear PUT_OOB status
+        ESOCTRL0 = ESOCTRL0_STATUS;
+
         if (cc & 0x80) {
             return -cc;
         } else {
@@ -273,6 +285,8 @@ int16_t peci_wr_pkg_config(uint8_t index, uint16_t param, uint32_t data) {
     } else {
         // Did not receive enough data
         DEBUG("peci_wr_pkg_config: len %d < 6\n", len);
+        // Clear PUT_OOB status
+        ESOCTRL0 = ESOCTRL0_STATUS;
         return -0x1000;
     }
 }


### PR DESCRIPTION
CONFIG_PECI_OVER_ESPI right now causes the ESPI interface to be stuck and not report any virtual wire updates. This causes the C10 reporting to not work (despite C10 residency was high in OS) and as a result the PECI keeps polling the temperature and S0ix cannot be entered. So CONFIG_PECI_OVER_ESPI cannot be used yet.

Fix the legacy PECI code, by ensuring the proper requirements are met for platforms using CONFIG_ESPI_BUS. That way C10 is correctly reported over ESPI and S0ix works.