### PR TITLE
Power on ac

### DIFF
--- a/src/board/system76/common/common.mk
+++ b/src/board/system76/common/common.mk
@@ -14,6 +14,7 @@ board-common-y += kbscan.c
 board-common-y += keymap.c
 board-common-y += lid.c
 board-common-y += main.c
+board-common-y += options.c
 board-common-y += parallel.c
 board-common-y += peci.c
 board-common-y += pmc.c
@@ -35,13 +36,13 @@ board-common-y += wireless.c
 # 3 - INFO
 # 4 - DEBUG
 # 5 - TRACE
-CFLAGS+=-DLEVEL=5
+CFLAGS+=-DLEVEL=0
 
 # Uncomment to enable debug logging over keyboard parallel port
-CFLAGS+=-DPARALLEL_DEBUG
+#CFLAGS+=-DPARALLEL_DEBUG
 
 # Uncomment to enable I2C debug on 0x76
-#CFLAGS+=-DI2C_DEBUGGER=0x76
+CFLAGS+=-DI2C_DEBUGGER=0x76
 
 ifeq ($(CONFIG_SECURITY),y)
 CFLAGS+=-DCONFIG_SECURITY=1

--- a/src/board/system76/common/common.mk
+++ b/src/board/system76/common/common.mk
@@ -35,13 +35,13 @@ board-common-y += wireless.c
 # 3 - INFO
 # 4 - DEBUG
 # 5 - TRACE
-CFLAGS+=-DLEVEL=0
+CFLAGS+=-DLEVEL=5
 
 # Uncomment to enable debug logging over keyboard parallel port
-#CFLAGS+=-DPARALLEL_DEBUG
+CFLAGS+=-DPARALLEL_DEBUG
 
 # Uncomment to enable I2C debug on 0x76
-CFLAGS+=-DI2C_DEBUGGER=0x76
+#CFLAGS+=-DI2C_DEBUGGER=0x76
 
 ifeq ($(CONFIG_SECURITY),y)
 CFLAGS+=-DCONFIG_SECURITY=1

--- a/src/board/system76/common/include/board/options.h
+++ b/src/board/system76/common/include/board/options.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#ifndef _BOARD_OPTIONS_H
+#define _BOARD_OPTIONS_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// Initialize the options
+void options_init(void);
+// Set the options to the default options
+void options_load_default(void);
+// Erase options in flash
+bool options_erase_config(void);
+// Load options from flash
+bool options_load_config(void);
+// Save options to flash
+bool options_save_config(void);
+// Get an option
+uint8_t options_get(uint16_t index);
+// Set an option
+bool options_set(uint16_t index, uint8_t value);
+
+enum {
+    OPT_POWER_ON_AC = 0,
+    NUM_OPTIONS
+};
+
+#endif // _BOARD_OPTIONS_H

--- a/src/board/system76/common/keymap.c
+++ b/src/board/system76/common/keymap.c
@@ -8,9 +8,9 @@ bool keymap_fnlock = false;
 uint16_t __xdata DYNAMIC_KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
 // Config is in the last sector of flash
-const uint32_t CONFIG_ADDR = 0x1FC00;
+const uint32_t KEYMAP_ADDR = 0x1FC00;
 // Signature is the size of the keymap
-const uint16_t CONFIG_SIGNATURE = sizeof(DYNAMIC_KEYMAP);
+const uint16_t KEYMAP_SIGNATURE = sizeof(DYNAMIC_KEYMAP);
 
 void keymap_init(void) {
     if (!keymap_load_config()) {
@@ -30,20 +30,20 @@ void keymap_load_default(void) {
 
 bool keymap_erase_config(void) {
     // This will erase 1024 bytes
-    flash_erase(CONFIG_ADDR);
+    flash_erase(KEYMAP_ADDR);
 
     // Verify signature is erased
-    return flash_read_u16(CONFIG_ADDR) == 0xFFFF;
+    return flash_read_u16(KEYMAP_ADDR) == 0xFFFF;
 }
 
 bool keymap_load_config(void) {
     // Check signature
-    if (flash_read_u16(CONFIG_ADDR) != CONFIG_SIGNATURE)
+    if (flash_read_u16(KEYMAP_ADDR) != KEYMAP_SIGNATURE)
         return false;
 
     // Read the keymap if signature is valid
     flash_read(
-        CONFIG_ADDR + sizeof(CONFIG_SIGNATURE),
+        KEYMAP_ADDR + sizeof(KEYMAP_SIGNATURE),
         (uint8_t *)DYNAMIC_KEYMAP,
         sizeof(DYNAMIC_KEYMAP)
     );
@@ -57,16 +57,16 @@ bool keymap_save_config(void) {
 
     // Write the keymap
     flash_write(
-        CONFIG_ADDR + sizeof(CONFIG_SIGNATURE),
+        KEYMAP_ADDR + sizeof(KEYMAP_SIGNATURE),
         (uint8_t *)DYNAMIC_KEYMAP,
         sizeof(DYNAMIC_KEYMAP)
     );
 
     // Write the length of the keymap, as a signature
-    flash_write_u16(CONFIG_ADDR, CONFIG_SIGNATURE);
+    flash_write_u16(KEYMAP_ADDR, KEYMAP_SIGNATURE);
 
     // Verify signature is valid
-    return flash_read_u16(CONFIG_ADDR) == CONFIG_SIGNATURE;
+    return flash_read_u16(KEYMAP_ADDR) == KEYMAP_SIGNATURE;
 }
 
 bool keymap_get(uint8_t layer, uint8_t output, uint8_t input, uint16_t *value) {

--- a/src/board/system76/common/main.c
+++ b/src/board/system76/common/main.c
@@ -18,6 +18,7 @@
 #include <board/kbscan.h>
 #include <board/keymap.h>
 #include <board/lid.h>
+#include <board/options.h>
 #include <board/peci.h>
 #include <board/pmc.h>
 #include <board/power.h>
@@ -73,6 +74,7 @@ void init(void) {
         kbscan_init();
     }
     keymap_init();
+    options_init();
     peci_init();
     pmc_init();
     pwm_init();

--- a/src/board/system76/common/options.c
+++ b/src/board/system76/common/options.c
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <board/flash.h>
+#include <board/options.h>
+#include <common/debug.h>
+
+uint8_t __xdata OPTIONS[NUM_OPTIONS];
+uint8_t DEFAULT_OPTIONS[NUM_OPTIONS] = { 0 };
+
+// Config is in the second to last sector of flash
+const uint32_t OPTIONS_ADDR = 0x1F800;
+// Signature is the size of the config
+const uint16_t OPTIONS_SIGNATURE = sizeof(OPTIONS);
+
+void options_init(void) {
+    if (!options_load_config()) {
+        options_load_default();
+    }
+}
+
+void options_load_default(void) {
+    for (uint8_t opt = 0; opt < NUM_OPTIONS; opt++) {
+        OPTIONS[opt] = DEFAULT_OPTIONS[opt];
+    }
+}
+
+bool options_erase_config(void) {
+    // This will erase 1024 bytes
+    flash_erase(OPTIONS_ADDR);
+
+    // Verify signature is erased
+    return flash_read_u16(OPTIONS_ADDR) == 0xFFFF;
+}
+
+bool options_load_config(void) {
+    // Check signature
+    if (flash_read_u16(OPTIONS_ADDR) != OPTIONS_SIGNATURE)
+        return false;
+
+    // Read the options if signature is valid
+    flash_read(OPTIONS_ADDR + sizeof(OPTIONS_SIGNATURE), (uint8_t *)OPTIONS, sizeof(OPTIONS));
+    return true;
+}
+
+bool options_save_config(void) {
+    // Erase config region
+    if (!options_erase_config())
+        return false;
+
+    // Write the options
+    flash_write(OPTIONS_ADDR + sizeof(OPTIONS_SIGNATURE), (uint8_t *)OPTIONS, sizeof(OPTIONS));
+
+    // Write the length of the options, as a signature
+    flash_write_u16(OPTIONS_ADDR, OPTIONS_SIGNATURE);
+
+    // Verify signature is valid
+    return flash_read_u16(OPTIONS_ADDR) == OPTIONS_SIGNATURE;
+}
+
+// TODO error handling
+uint8_t options_get(uint16_t index) {
+    if (index < NUM_OPTIONS) {
+        TRACE("OPTION %x READ %x\n", index, OPTIONS[index]);
+        return OPTIONS[index];
+    } else {
+        return 0;
+    }
+}
+
+bool options_set(uint16_t index, uint8_t value) {
+    if (index < NUM_OPTIONS && OPTIONS[value] != value) {
+        OPTIONS[index] = value;
+        TRACE("OPTION %x WRITE %x\n", index, value);
+        return options_save_config();
+    } else {
+        return false;
+    }
+}

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -11,6 +11,7 @@
 #include <board/kbc.h>
 #include <board/kbled.h>
 #include <board/lid.h>
+#include <board/options.h>
 #include <board/peci.h>
 #include <board/power.h>
 #include <board/pmc.h>
@@ -441,6 +442,20 @@ void power_event(void) {
             // Set CPU power limit to AC limit
             //TODO: if this returns false, retry?
             power_peci_limit(true);
+            if (options_get(OPT_POWER_ON_AC) == 1) {
+                switch (power_state) {
+                case POWER_STATE_OFF:
+                    power_on();
+                    break;
+                case POWER_STATE_S5:
+                    GPIO_SET_DEBUG(PWR_BTN_N, false);
+                    delay_ms(32); // PWRBTN# must assert for at least 16 ms, we do twice that
+                    GPIO_SET_DEBUG(PWR_BTN_N, true);
+                    break;
+                default:
+                    break;
+                }
+            }
         }
         battery_debug();
 

--- a/src/board/system76/common/smfi.c
+++ b/src/board/system76/common/smfi.c
@@ -37,6 +37,7 @@
 #include <common/command.h>
 #include <common/macro.h>
 #include <common/version.h>
+#include <board/options.h>
 #include <board/kbscan.h>
 #include <ec/etwd.h>
 #include <ec/pwm.h>
@@ -311,6 +312,15 @@ static enum Result cmd_wifi_bt_enablement_set(void) {
     return RES_OK;
 }
 
+static enum Result cmd_option_get(void) {
+    smfi_cmd[SMFI_CMD_DATA] = options_get(smfi_cmd[SMFI_CMD_DATA]);
+    return RES_OK;
+}
+
+static enum Result cmd_option_set(void) {
+    return !options_set(smfi_cmd[SMFI_CMD_DATA], smfi_cmd[SMFI_CMD_DATA + 1]);
+}
+
 #endif // !defined(__SCRATCH__)
 
 #if defined(__SCRATCH__)
@@ -466,6 +476,12 @@ void smfi_event(void) {
             break;
         case CMD_WIFI_BT_ENABLEMENT_SET:
             smfi_cmd[SMFI_CMD_RES] = cmd_wifi_bt_enablement_set();
+            break;
+        case CMD_OPTION_GET:
+            smfi_cmd[SMFI_CMD_RES] = cmd_option_get();
+            break;
+        case CMD_OPTION_SET:
+            smfi_cmd[SMFI_CMD_RES] = cmd_option_set();
             break;
 #if CONFIG_SECURITY
         case CMD_SECURITY_GET:

--- a/src/common/include/common/command.h
+++ b/src/common/include/common/command.h
@@ -56,6 +56,10 @@ enum Command {
     CMD_CAMERA_ENABLEMENT_SET = 23,
     // Set WiFi + Bluetooth card enablement
     CMD_WIFI_BT_ENABLEMENT_SET = 24,
+    // Get a persistent option by index
+    CMD_OPTION_GET = 25,
+    // Set a persistent option by index
+    CMD_OPTION_SET = 26,
     //TODO
 };
 


### PR DESCRIPTION
persistent option code based on the dynamic keymap implementation. currently only designed for u8 options, can be used for e.g. battery thresholds, fan curve, keyboard backlight mode, instead of restoring their state in coreboot on every boot. For now only Power on AC feature is implemented.