### PR TITLE
Implement persistent options for keyboard backlight

### DIFF
--- a/src/board/system76/common/include/board/options.h
+++ b/src/board/system76/common/include/board/options.h
@@ -8,12 +8,6 @@
 
 // Initialize the options
 void options_init(void);
-// Set the options to the default options
-void options_load_default(void);
-// Erase options in flash
-bool options_erase_config(void);
-// Load options from flash
-bool options_load_config(void);
 // Save options to flash
 bool options_save_config(void);
 // Get an option
@@ -23,6 +17,12 @@ bool options_set(uint16_t index, uint8_t value);
 
 enum {
     OPT_POWER_ON_AC = 0,
+    OPT_KBLED_BRIGHTNESS,
+    OPT_KBLED_COLOR_R,
+    OPT_KBLED_COLOR_G,
+    OPT_KBLED_COLOR_B,
+    OPT_BAT_THRESHOLD_START,
+    OPT_BAT_THRESHOLD_STOP,
     NUM_OPTIONS
 };
 

--- a/src/board/system76/common/kbled.c
+++ b/src/board/system76/common/kbled.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/kbled.h>
+#include <board/options.h>
 #include <common/macro.h>
 
 enum KbledKind kbled_kind = KBLED_NONE;
@@ -58,6 +59,7 @@ void kbled_set_brightness(uint8_t value) {
     if (enabled) {
         kbled_set(brightness);
     }
+    options_set(OPT_KBLED_BRIGHTNESS, brightness);
 }
 
 void kbled_hotkey_color(void) {
@@ -67,6 +69,9 @@ void kbled_hotkey_color(void) {
         COLOR_I = 0;
     }
     kbled_set_color(COLORS[COLOR_I]);
+    options_set(OPT_KBLED_COLOR_B, (uint8_t)COLORS[COLOR_I]);
+    options_set(OPT_KBLED_COLOR_G, (uint8_t)(COLORS[COLOR_I] >> 8));
+    options_set(OPT_KBLED_COLOR_R, (uint8_t)(COLORS[COLOR_I] >> 16));
 }
 
 void kbled_hotkey_down(void) {

--- a/src/board/system76/common/kbled/rgb_pwm.c
+++ b/src/board/system76/common/kbled/rgb_pwm.c
@@ -2,6 +2,7 @@
 
 #include <board/gpio.h>
 #include <board/kbled.h>
+#include <board/options.h>
 #include <ec/pwm.h>
 
 void kbled_init(void) {
@@ -18,10 +19,14 @@ void kbled_init(void) {
 
 void kbled_reset(void) {
     // Set brightness and color
-    kbled_set_brightness(0);
+    kbled_set_brightness(options_get(OPT_KBLED_BRIGHTNESS));
     if (gpio_get(&LID_SW_N))
         kbled_enable(true);
-    kbled_set_color(0xFFFFFF);
+    kbled_set_color(
+          (uint32_t)options_get(OPT_KBLED_COLOR_B)
+        | (uint32_t)options_get(OPT_KBLED_COLOR_G) << 8
+        | (uint32_t)options_get(OPT_KBLED_COLOR_R) << 16
+        );
 }
 
 uint8_t kbled_get(void) {

--- a/src/board/system76/common/kbled/white_dac.c
+++ b/src/board/system76/common/kbled/white_dac.c
@@ -20,7 +20,7 @@ void kbled_init(void) {
 }
 
 void kbled_reset(void) {
-    kbled_set_brightness(0);
+    kbled_set_brightness(options_get(OPT_KBLED_BRIGHTNESS));
     if (gpio_get(&LID_SW_N))
         kbled_enable(true);
 }

--- a/src/board/system76/common/kbscan.c
+++ b/src/board/system76/common/kbscan.c
@@ -185,16 +185,13 @@ static void hardware_hotkey(uint16_t key) {
         kbled_hotkey_color();
         break;
     case K_KBD_DOWN:
-        if (acpi_ecos != EC_OS_FULL)
-            kbled_hotkey_down();
+        kbled_hotkey_down();
         break;
     case K_KBD_UP:
-        if (acpi_ecos != EC_OS_FULL)
-            kbled_hotkey_up();
+        kbled_hotkey_up();
         break;
     case K_KBD_TOGGLE:
-        if (acpi_ecos != EC_OS_FULL)
-            kbled_hotkey_toggle();
+        kbled_hotkey_toggle();
         break;
     }
 }

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -293,6 +293,9 @@ void power_on(void) {
 void power_off(void) {
     DEBUG("%02X: power_off\n", main_cycle);
 
+    // Commit settings to flash on shutdown
+    options_save_config();
+
 #if HAVE_PCH_PWROK_EC
     // De-assert SYS_PWROK
     GPIO_SET_DEBUG(PCH_PWROK_EC, false);

--- a/src/board/system76/common/smfi.c
+++ b/src/board/system76/common/smfi.c
@@ -197,54 +197,6 @@ static enum Result cmd_keymap_set(void) {
     }
 }
 
-static enum Result cmd_led_get_value(void) {
-    uint8_t index = smfi_cmd[SMFI_CMD_DATA];
-    if (index == CMD_LED_INDEX_ALL) {
-        smfi_cmd[SMFI_CMD_DATA + 1] = kbled_get();
-        smfi_cmd[SMFI_CMD_DATA + 2] = kbled_max();
-        return RES_OK;
-    } else {
-        return RES_ERR;
-    }
-}
-
-static enum Result cmd_led_set_value(void) {
-    uint8_t index = smfi_cmd[SMFI_CMD_DATA];
-    if (index == CMD_LED_INDEX_ALL) {
-        kbled_set_brightness(smfi_cmd[SMFI_CMD_DATA + 1]);
-        return RES_OK;
-    } else {
-        return RES_ERR;
-    }
-}
-
-static enum Result cmd_led_get_color(void) {
-    uint8_t index = smfi_cmd[SMFI_CMD_DATA];
-    if (index == CMD_LED_INDEX_ALL) {
-        uint32_t color = kbled_get_color();
-        smfi_cmd[SMFI_CMD_DATA + 1] = (uint8_t)(color >> 16);
-        smfi_cmd[SMFI_CMD_DATA + 2] = (uint8_t)(color >> 8);
-        smfi_cmd[SMFI_CMD_DATA + 3] = (uint8_t)(color >> 0);
-        return RES_OK;
-    } else {
-        return RES_ERR;
-    }
-}
-
-static enum Result cmd_led_set_color(void) {
-    uint8_t index = smfi_cmd[SMFI_CMD_DATA];
-    if (index == CMD_LED_INDEX_ALL) {
-        kbled_set_color(
-            (((uint32_t)smfi_cmd[SMFI_CMD_DATA + 1]) << 16) |
-            (((uint32_t)smfi_cmd[SMFI_CMD_DATA + 2]) << 8) |
-            (((uint32_t)smfi_cmd[SMFI_CMD_DATA + 3]) << 0)
-        );
-        return RES_OK;
-    } else {
-        return RES_ERR;
-    }
-}
-
 static enum Result cmd_matrix_get(void) {
     smfi_cmd[SMFI_CMD_DATA] = KM_OUT;
     smfi_cmd[SMFI_CMD_DATA + 1] = KM_IN;
@@ -452,18 +404,6 @@ void smfi_event(void) {
             break;
         case CMD_KEYMAP_SET:
             smfi_cmd[SMFI_CMD_RES] = cmd_keymap_set();
-            break;
-        case CMD_LED_GET_VALUE:
-            smfi_cmd[SMFI_CMD_RES] = cmd_led_get_value();
-            break;
-        case CMD_LED_SET_VALUE:
-            smfi_cmd[SMFI_CMD_RES] = cmd_led_set_value();
-            break;
-        case CMD_LED_GET_COLOR:
-            smfi_cmd[SMFI_CMD_RES] = cmd_led_get_color();
-            break;
-        case CMD_LED_SET_COLOR:
-            smfi_cmd[SMFI_CMD_RES] = cmd_led_set_color();
             break;
         case CMD_MATRIX_GET:
             smfi_cmd[SMFI_CMD_RES] = cmd_matrix_get();


### PR DESCRIPTION
Remove SW controls for keyboard backlight. EC is the only entity in control of kbled.

Restore state from the flash and save to flash on `power_off()`.