### PR TITLE
board/common: add s0ix and display hooks for PEP

### DIFF
--- a/src/board/system76/common/acpi.c
+++ b/src/board/system76/common/acpi.c
@@ -7,6 +7,7 @@
 #include <board/kbled.h>
 #include <board/lid.h>
 #include <board/peci.h>
+#include <board/power.h>
 #include <common/macro.h>
 #include <common/debug.h>
 #include <ec/pwm.h>
@@ -133,8 +134,13 @@ uint8_t acpi_read(uint8_t addr) {
             break;
 #endif // HAVE_LED_AIRPLANE_N
 
-        // Set size of flash (from old firmware)
-        ACPI_8 (0xE5, 0x80);
+        // S0ix hook
+        case 0xE0:
+            data = pep_in_s0ix;
+            break;
+        case 0xE1:
+            data = pep_display_on;
+            break;
     }
 
     TRACE("acpi_read %02X = %02X\n", addr, data);
@@ -169,5 +175,13 @@ void acpi_write(uint8_t addr, uint8_t data) {
         gpio_set(&LED_AIRPLANE_N, !(bool)(data & BIT(6)));
         break;
 #endif
+    // S0ix hook
+    case 0xE0:
+        pep_in_s0ix = !!data;
+        break;
+    // Display hook
+    case 0xE1:
+        pep_display_on = !!data;
+        break;
     }
 }

--- a/src/board/system76/common/acpi.c
+++ b/src/board/system76/common/acpi.c
@@ -134,12 +134,9 @@ uint8_t acpi_read(uint8_t addr) {
             break;
 #endif // HAVE_LED_AIRPLANE_N
 
-        // S0ix hook
+        // Power engine plug-in hook for S0ix
         case 0xE0:
-            data = pep_in_s0ix;
-            break;
-        case 0xE1:
-            data = pep_display_on;
+            data = pep_hook;
             break;
     }
 
@@ -175,13 +172,9 @@ void acpi_write(uint8_t addr, uint8_t data) {
         gpio_set(&LED_AIRPLANE_N, !(bool)(data & BIT(6)));
         break;
 #endif
-    // S0ix hook
+    // Power engine plug-in hook for S0ix
     case 0xE0:
-        pep_in_s0ix = !!data;
-        break;
-    // Display hook
-    case 0xE1:
-        pep_display_on = !!data;
+        pep_hook = data;
         break;
     }
 }

--- a/src/board/system76/common/include/board/power.h
+++ b/src/board/system76/common/include/board/power.h
@@ -16,8 +16,9 @@ extern enum PowerState power_state;
 void update_power_state(void);
 
 #if USE_S0IX
-extern bool pep_in_s0ix;
-extern bool pep_display_on;
+#define PEP_S0IX_FLAG BIT(0)
+#define PEP_DISPLAY_FLAG BIT(1)
+extern uint8_t pep_hook;
 #endif
 
 void power_init(void);

--- a/src/board/system76/common/include/board/power.h
+++ b/src/board/system76/common/include/board/power.h
@@ -16,7 +16,8 @@ extern enum PowerState power_state;
 void update_power_state(void);
 
 #if USE_S0IX
-extern bool in_s0ix;
+extern bool pep_in_s0ix;
+extern bool pep_display_on;
 #endif
 
 void power_init(void);

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -131,8 +131,7 @@ extern uint8_t main_cycle;
 enum PowerState power_state = POWER_STATE_OFF;
 
 #if USE_S0IX
-bool pep_in_s0ix = false;
-bool pep_display_on = true;
+uint8_t pep_hook = PEP_DISPLAY_FLAG;
 #endif
 
 enum PowerState calculate_power_state(void) {
@@ -639,7 +638,7 @@ void power_event(void) {
     uint32_t time = time_get();
     if (power_state == POWER_STATE_S0) {
 #if USE_S0IX
-        if (pep_in_s0ix) {
+        if (pep_hook & PEP_S0IX_FLAG) {
             // Modern suspend, flashing green light
             if ((time - last_time) >= 1000) {
                 gpio_set(&LED_PWR, !gpio_get(&LED_PWR));
@@ -654,7 +653,7 @@ void power_event(void) {
             gpio_set(&LED_PWR, true);
             gpio_set(&LED_ACIN, false);
 
-            if (gpio_get(&LID_SW_N) && pep_display_on)
+            if (gpio_get(&LID_SW_N) && (pep_hook & PEP_DISPLAY_FLAG))
                 kbled_enable(true);
             else
                 kbled_enable(false);


### PR DESCRIPTION
Display hook controls keyboard backlight and S0ix hook controls LED blinking.

Fixes long delay from trying to go to sleep to the keyboard backlight turning off. Also fixes spurious backlight blinking whenever windows briefly wakes up in s0ix.

The old logic worked fine for Linux, but Windows never worked well with it. We added a 1s timeout as a band-aid solution but it didn't solve the s0ix entry latency problem and it had other issues. Remove the old logic and simply follow what the OSPM tells us via PEP.

Needs https://github.com/Dasharo/coreboot/pull/433