### PR TITLE
Ensure good PD controller state on boot

### DIFF
--- a/src/board/system76/common/include/board/usbpd.h
+++ b/src/board/system76/common/include/board/usbpd.h
@@ -3,10 +3,23 @@
 #ifndef _BOARD_USBPD_H
 #define _BOARD_USBPD_H
 
+enum {
+    // Fully functional, normal operation
+    USBPD_MODE_APP = 0,
+    // PD controller is running BIST
+    USBPD_MODE_BIST,
+    // PD controller booted in dead battery mode
+    USBPD_MODE_BOOT,
+    // Simulated port disconnect by previously issued DISC command
+    USBPD_MODE_DISC,
+    // Other values indicate limited functionality
+    USBPD_MODE_UNKNOWN,
+};
+
 void usbpd_init(void);
 void usbpd_event(void);
 void usbpd_disable_charging(void);
 void usbpd_enable_charging(void);
-int16_t usbpd_disc(uint8_t timeout);
+void usbpd_set_mode(int16_t mode);
 
 #endif // _BOARD_USBPD_H

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -294,7 +294,7 @@ void power_off(void) {
     options_save_config();
 
     // Trigger USB-PD disconnect, will be reconnected after TI reset
-    usbpd_disc(0);
+    usbpd_disc(1);
 
 #if HAVE_PCH_PWROK_EC
     // De-assert SYS_PWROK

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -293,8 +293,10 @@ void power_off(void) {
     // Commit settings to flash on shutdown
     options_save_config();
 
-    // Trigger USB-PD disconnect, will be reconnected after TI reset
-    usbpd_disc(1);
+    // Cycle the PD controller and dock connection off and on to work around
+    // dock issues
+    usbpd_set_mode(USBPD_MODE_DISC);
+    usbpd_set_mode(USBPD_MODE_APP);
 
 #if HAVE_PCH_PWROK_EC
     // De-assert SYS_PWROK


### PR DESCRIPTION
Make sure that we're not stuck in the wrong mode after a shutdown. With some power supplies, this can manifest as the power LED blinking orange when the laptop is off and the charger being stuck at 5V.