### PR TITLE
Dual CPU fan fixes

### DIFF
--- a/src/board/system76/common/acpi.c
+++ b/src/board/system76/common/acpi.c
@@ -115,15 +115,17 @@ uint8_t acpi_read(uint8_t addr) {
 
         ACPI_8(0xCC, sci_extra);
 
-        ACPI_8(0xCE, DCR2);
-#if HAVE_CPU_FAN2
-        ACPI_8(0xCF, DCR3);
-#endif
+        ACPI_8(0xCE, PWM_REG(CPU_FAN1));
         ACPI_8(0xD0, F1TLRR);
         ACPI_8(0xD1, F1TMRR);
+#ifdef CPU_FAN2
+        ACPI_8(0xCF, PWM_REG(CPU_FAN2));
+        ACPI_8(0xD2, F2TLRR);
+        ACPI_8(0xD3, F2TMRR);
+#endif
 #if HAVE_DGPU
         ACPI_8(0xCD, dgpu_temp);
-        ACPI_8(0xCF, DCR4);
+        ACPI_8(0xCF, PWM_REG(GPU_FAN1));
         ACPI_8(0xD2, F2TLRR);
         ACPI_8(0xD3, F2TMRR);
 

--- a/src/board/system76/common/acpi.c
+++ b/src/board/system76/common/acpi.c
@@ -16,6 +16,10 @@
 #define HAVE_LED_AIRPLANE_N 1
 #endif // HAVE_LED_AIRPLANE_N
 
+#if defined(CPU_FAN2) && HAVE_DGPU == 1
+#error "CPU_FAN2 and HAVE_DGPU are mutually exclusive"
+#endif
+
 extern uint8_t sci_extra;
 
 enum EcOs acpi_ecos = EC_OS_NONE;

--- a/src/board/system76/common/main.c
+++ b/src/board/system76/common/main.c
@@ -46,7 +46,9 @@ void timer_2(void) __interrupt(5) {}
 
 uint8_t main_cycle = 0;
 const uint16_t battery_interval = 1000;
-const uint16_t fan_interval = 1000;
+// update fan speed more frequently for smoother fans
+// NOTE: event loop is longer than 100ms and maybe even longer than 250
+const uint16_t fan_interval = SMOOTH_FANS != 0 ? 250 : 1000;
 
 void init(void) {
     // Must happen first

--- a/src/board/system76/common/pwm.c
+++ b/src/board/system76/common/pwm.c
@@ -26,7 +26,7 @@ void pwm_init(void) {
 
     // Turn off CPU fan (temperature control in peci_get_fan_duty)
     PWM_REG(CPU_FAN1) = 0;
-#if HAVE_CPU_FAN2
+#ifdef CPU_FAN2
     PWM_REG(CPU_FAN2) = 0;
 #endif
 #if HAVE_DGPU

--- a/src/board/system76/common/scratch.c
+++ b/src/board/system76/common/scratch.c
@@ -18,7 +18,7 @@ uint8_t __code __at(SCRATCH_OFFSET) scratch_rom[] = {
 void scratch_trampoline(void) {
     // Set fans to 100%
     PWM_REG(CPU_FAN1) = 0xFF;
-#if HAVE_CPU_FAN2
+#ifdef CPU_FAN2
     PWM_REG(CPU_FAN2) = 0xFF;
 #endif
 #if HAVE_DGPU

--- a/src/board/system76/common/smfi.c
+++ b/src/board/system76/common/smfi.c
@@ -152,7 +152,7 @@ static enum Result cmd_fan_set(void) {
     case 0:
         // Set duty cycle of fan 0
         PWM_REG(CPU_FAN1) = smfi_cmd[SMFI_CMD_DATA + 1];
-#if HAVE_CPU_FAN2
+#ifdef CPU_FAN2
         // TODO handle CPU fan 2 separately
         PWM_REG(CPU_FAN2) = smfi_cmd[SMFI_CMD_DATA + 1];
 #endif


### PR DESCRIPTION
- Use the PWM_REG macro in acpi.c
- Hook up fan 2 tach for dual CPU fans
- Fix incorrect ifdef for checking dual cpu fans
- Restore previous fan polling interval