### PR TITLE
board/system76/common: Support the S4 power state

### DIFF
--- a/src/board/system76/common/include/board/power.h
+++ b/src/board/system76/common/include/board/power.h
@@ -10,6 +10,8 @@ enum PowerState {
     POWER_STATE_S0 = 0x0,
     // Suspend to RAM
     POWER_STATE_S3 = 0x3,
+    // Suspend to Disk
+    POWER_STATE_S4 = 0x4,
     // Soft off
     POWER_STATE_S5 = 0x5,
     // Only USB is powered (Always On USB)

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -153,9 +153,14 @@ enum PowerState calculate_power_state(void) {
 #if CONFIG_BUS_ESPI
     // Use eSPI virtual wires if available
 
+    if (vw_get(&VW_SLP_S5_N) != VWS_HIGH) {
+        // S5 plane not powered
+        return POWER_STATE_S5;
+    }
+
     if (vw_get(&VW_SLP_S4_N) != VWS_HIGH) {
         // S4 plane not powered
-        return POWER_STATE_S5;
+        return POWER_STATE_S4;
     }
 
     if (vw_get(&VW_SLP_S3_N) != VWS_HIGH) {
@@ -198,6 +203,9 @@ void update_power_state(void) {
             break;
         case POWER_STATE_S5:
             DEBUG("POWER_STATE_S5\n");
+            break;
+        case POWER_STATE_S4:
+            DEBUG("POWER_STATE_S4\n");
             break;
         case POWER_STATE_S3:
             DEBUG("POWER_STATE_S3\n");
@@ -742,8 +750,8 @@ void power_event(void) {
         // AC plugged in, orange light
         gpio_set(&LED_PWR, false);
         gpio_set(&LED_ACIN, true);
-    } else if (power_state == POWER_STATE_G3_AOU) {
-        // G3, Always on USB, lights off
+    } else if (power_state == POWER_STATE_G3_AOU || power_state == POWER_STATE_S4) {
+        // G3 + Always on USB or S4, lights off
         gpio_set(&LED_PWR, false);
         gpio_set(&LED_ACIN, false);
     } else {


### PR DESCRIPTION
Add support for the S4 power state on eSPI platforms, and handle it properly, which in contrast to S5, does not power off the platform. In this state, more wake sources are available, like rtcwake.

Make sure the power LED is off while in S4, same as in G3.