### PR TITLE
Allow flashing non-Dasharo EC firmware and fix edge case key detection

### DIFF
--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -38,6 +38,7 @@ elif [[ "${ID}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "fedora" ]]; then
         avr-libc \
         avrdude \
         clang-tools-extra \
+        hidapi-devel \
         curl \
         gcc \
         make \

--- a/tool/src/firmware.rs
+++ b/tool/src/firmware.rs
@@ -23,11 +23,6 @@ fn firmware_str<'a>(data: &'a [u8], key: &[u8]) -> Option<&'a [u8]> {
         data_i += 1;
     }
 
-    // Return None if key not found
-    if key_i < key.len() {
-        return None;
-    }
-
     // Locate end of data
     let start = data_i;
     while data_i < data.len() {

--- a/tool/src/firmware.rs
+++ b/tool/src/firmware.rs
@@ -15,6 +15,8 @@ fn firmware_str<'a>(data: &'a [u8], key: &[u8]) -> Option<&'a [u8]> {
     while data_i < data.len() && key_i < key.len() {
         if data[data_i] == key[key_i] {
             key_i += 1;
+        } else if data[data_i] == key[0] {
+            key_i = 1;
         } else {
             key_i = 0;
         }

--- a/tool/src/firmware.rs
+++ b/tool/src/firmware.rs
@@ -7,7 +7,7 @@ pub struct Firmware<'a> {
     pub data: &'a [u8],
 }
 
-fn firmware_str<'a>(data: &'a [u8], key: &[u8]) -> Option<&'a [u8]> {
+fn firmware_str<'a>(data: &'a [u8], key: &[u8]) -> &'a [u8] {
     let mut data_i = 0;
 
     //First, locate the key
@@ -32,14 +32,14 @@ fn firmware_str<'a>(data: &'a [u8], key: &[u8]) -> Option<&'a [u8]> {
         data_i += 1;
     }
 
-    Some(&data[start..data_i])
+    &data[start..data_i]
 }
 
 impl<'a> Firmware<'a> {
     /// Parses firmware board and version, and then returns firmware object
     pub fn new(data: &'a [u8]) -> Option<Self> {
-        let board = firmware_str(data, b"76EC_BOARD=")?;
-        let version = firmware_str(data, b"76EC_VERSION=")?;
+        let board = firmware_str(data, b"76EC_BOARD=");
+        let version = firmware_str(data, b"76EC_VERSION=");
         Some(Self {
             data,
             board,


### PR DESCRIPTION
Needs to be tested on hardware, but with those changes `dasharo_ectool` should allow flashing non-Dasharo firmware.
When trying to flash vendor EC, tool should display:

```
file board: Ok("")
file version: Ok("")
```

Also fixed edge case key detection failure, where `firmware_str` wouldn't find `76EC_*` string if previous byte was also `7`.
Fixes https://github.com/Dasharo/dasharo-issues/issues/1628