### PR TITLE
common/{dgpu,peci}.c: increase board heatup size

### DIFF
--- a/src/board/system76/common/dgpu.c
+++ b/src/board/system76/common/dgpu.c
@@ -17,7 +17,7 @@
 
 // Fan speed is the lowest requested over HEATUP seconds
 #ifndef BOARD_DGPU_HEATUP
-#define BOARD_DGPU_HEATUP 4
+#define BOARD_DGPU_HEATUP 12
 #endif
 
 static uint8_t FAN_HEATUP[BOARD_DGPU_HEATUP] = { 0 };

--- a/src/board/system76/common/peci.c
+++ b/src/board/system76/common/peci.c
@@ -17,7 +17,7 @@
 
 // Fan speed is the lowest requested over HEATUP seconds
 #ifndef BOARD_HEATUP
-#define BOARD_HEATUP 4
+#define BOARD_HEATUP 12
 #endif
 
 static uint8_t FAN_HEATUP[BOARD_HEATUP] = { 0 };


### PR DESCRIPTION
This results in similar behavior to V5x0TU v0.9.0 where it takes a much longer time for the fans to spin up, resulting in a quieter laptop during bursty CPU loads.