### PR TITLE
common/power.c: Reset USB-PD on host reset

### DIFF
--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -473,6 +473,8 @@ void power_cpu_reset(void) {
     // Set GPIO MUX_CTRL_BIOS to choose between iGPU and dGPU
     set_mux_ctrl();
 #endif //HAVE_DGPU
+    // Reset USB-PD device
+    usbpd_reset();
     // LPC was just reset, enable PNP devices
     pnp_enable();
     // Reset ACPI registers


### PR DESCRIPTION
This improves device detection after a reboot with the Wavlink UMD05 Pro USB-C docking station (Rev. E).