### PR TITLE
build: allow overriding docker UID for rootless environments

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,8 @@ Usage: ./$(basename "${0}")
   Environmental variables:
     EC_BOARD_VENDOR        name of the board vendor (required)
     EC_BOARD_MODEL         name of the board model (required)
+    DOCKER_UID             user ID to run Docker container as (default: current user ID)
+                           Set to 'root' for rootless Docker setups
 
 Example usage to build for NovaCustom NV40 series:
     EC_BOARD_VENDOR=clevo EC_BOARD_MODEL=nv40mz ./$(basename "$0")
@@ -70,7 +72,8 @@ if [ "$EC_BOARD_VENDOR" = "novacustom" ] ; then
   esac
 fi
 
-docker run --rm -v "$PWD":"$PWD" -w "$PWD" -u "$(id -u)" \
+DOCKER_UID="${DOCKER_UID:-$(id -u)}"
+docker run --rm -v "$PWD":"$PWD" -w "$PWD" -u "$DOCKER_UID" \
   ghcr.io/dasharo/ec-sdk:main make BOARD="${EC_BOARD_VENDOR}/${EC_BOARD_MODEL}"
 errorCheck "Failed to build EC firmware"
 


### PR DESCRIPTION
### Description

This PR enables building the EC firmware using a rootless Docker setup, fixing [Dasharo/dasharo-issues#1197](https://github.com/Dasharo/dasharo-issues/issues/1197).

Currently, `build.sh` hardcodes the user ID passed to the Docker container via `-u "$(id -u)"`. In a rootless Docker environment, the Docker daemon runs in userspace, and forcing the host's UID inside the container causes user-namespace mapping issues, leading to `Permission denied` errors.

This introduces a `DOCKER_UID` environment variable that falls back to `$(id -u)`. This allows developers using rootless Docker to easily bypass the restriction by running:

```bash
DOCKER_UID=root EC_BOARD_VENDOR=clevo EC_BOARD_MODEL=nv40mz ./build.sh
```

Because of rootless Docker user namespaces, the container runs as `root` internally, but the resulting `.rom` file is safely owned by the standard developer user on the host machine.

### Testing

- **Standard Docker (Regression Test):**  
  ```bash
  BUILD_TIMELESS=1 EC_BOARD_VENDOR=clevo EC_BOARD_MODEL=nv40mz ./build.sh
  ```
  Builds successfully.

- **Rootless Docker:**  
  ```bash
  BUILD_TIMELESS=1 DOCKER_UID=root EC_BOARD_VENDOR=clevo EC_BOARD_MODEL=nv40mz ./build.sh
  ```
  Successfully completes the build.

- **Verification:**  
  The SHA256 hashes of the resulting `ec.rom` files match perfectly between both build environments, confirming reproducible builds without permission errors.