### PR TITLE
build.sh: parametrize docker user for rootless Docker support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -43,6 +43,7 @@ EC_GIT_REV="$(git rev-parse --short HEAD)"
 EC_BUILD_DIR="build/${EC_BOARD_VENDOR}/${EC_BOARD_MODEL}/${EC_GIT_DATE}_${EC_GIT_REV:0:7}"
 EC_ROM="${EC_BUILD_DIR}/ec.rom"
 EC_ARTIFACT="${EC_BOARD_VENDOR}_${EC_BOARD_MODEL}_ec.rom"
+DOCKER_UID="${UID:-$(id -u)}"
 
 # For already released boards, keep the original names (already present in the
 # released firmwares) to avoid the necessity of force-flashing during EC
@@ -70,7 +71,7 @@ if [ "$EC_BOARD_VENDOR" = "novacustom" ] ; then
   esac
 fi
 
-docker run --rm -v "$PWD":"$PWD" -w "$PWD" -u "$(id -u)" \
+docker run --rm -v "$PWD":"$PWD" -w "$PWD" -u "$DOCKER_UID" \
   ghcr.io/dasharo/ec-sdk:main make BOARD="${EC_BOARD_VENDOR}/${EC_BOARD_MODEL}"
 errorCheck "Failed to build EC firmware"
 


### PR DESCRIPTION
Rootless Docker builds fail because ec/build.sh was not passing a build user into docker run the way coreboot/build.sh already does. This change adds a UID-derived variable near the top of build.sh and uses it with -u in docker run.

Tested with bash -n build.sh.

Related to Dasharo/dasharo-issues#1197.